### PR TITLE
chore: Update Go version in GoReleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.1
+          go-version: 1.23.5
           cache: true
 
       # Run tests before proceeding


### PR DESCRIPTION
Bump Go version from 1.22.1 to 1.23.5 in GitHub Actions release configuration