### PR TITLE
ci: Remove unnecessary git dependency in AUR package build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,6 @@ jobs:
           license=('0BSD')
           provides=('td')
           conflicts=('td')
-          depends=('git')
           
           source_x86_64=("https://github.com/voioo/td/releases/download/v\${pkgver}/td_linux_amd64.tar.gz")
           source_aarch64=("https://github.com/voioo/td/releases/download/v\${pkgver}/td_linux_arm64.tar.gz")


### PR DESCRIPTION
## Description
Remove unnecessary git dependency from PKGBUILD. The td binary is a standalone executable that doesn't require Git as a runtime dependency.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes:
- [ ] Unit tests
- [x] Integration tests

**Test Configuration**:
* Hardware: x86_64
* OS: Arch Linux
* Go version: 1.23.5

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
