### PR TITLE
fix: Change undo keybinding from 'u' to 'ctrl+u'

### DIFF
--- a/cmd/td/keymap.go
+++ b/cmd/td/keymap.go
@@ -96,8 +96,8 @@ var keys = keyMap{
 		key.WithHelp("f", "filter by priority"),
 	),
 	Undo: key.NewBinding(
-		key.WithKeys("u"),
-		key.WithHelp("u", "undo"),
+		key.WithKeys("ctrl+u"),
+		key.WithHelp("ctrl+u", "undo"),
 	),
 	Redo: key.NewBinding(
 		key.WithKeys("ctrl+r"),


### PR DESCRIPTION
## Description
Change undo keybinding from 'u' to 'ctrl+u' to prevent accidental operations.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Documentation update
